### PR TITLE
Solve: bottleneck saving results in the GUI

### DIFF
--- a/gui/utils/gui_add_nodes.m
+++ b/gui/utils/gui_add_nodes.m
@@ -1,9 +1,9 @@
-function gui_add_nodes(obj_parent, results)
+function gui_add_nodes(parent_node, results)
     % Function that generate nodes in a UITree and save data on them.
-    % 1. Generate Nodes (childrens)
+
     % * Category 1: new children node: Results -> ProblemType
     match_text = strcat('Problem Type: ', results(1).ProblemType);
-    category1 = set_node(obj_parent, match_text);
+    category1 = set_node(parent_node, match_text);
     % * Category 2: new children node: ProblemType -> Reactants
     match_text = strcat('Reactants: ', results(1).Reactants);
     category2 = set_node(category1, match_text);
@@ -21,16 +21,18 @@ end
 function category_children = set_node(category_parent, match_text, varargin)
     % Default values
     NodeData = [];
+    FLAG_CHECK = true;
     % Check varargin inputs
     for i = 1:nargin - 3
         switch lower(varargin{i})
             case 'nodedata'
                 NodeData = varargin{i + 1};
+                FLAG_CHECK = false;
         end
     end
     % Set node
     j = 0;
-    if ~isempty(category_parent.Children)
+    if ~isempty(category_parent.Children) && FLAG_CHECK
         i = 1;
         while i <= length(category_parent.Children)
             if strcmpi(category_parent.Children(i).Text, match_text)


### PR DESCRIPTION
* #4

There was a significant bottleneck when saving the results of the parametric studies in the UITree nodes.

For example: the calculation of the adiabatic combustion of a methane-air mixture at standard conditions for a set of equivalence ratios \in [0.5, 4] with a step_phi = 0.01 took about 20 seconds to save the data in the nodes. Now it takes 1 second.