### PR TITLE
Hotfix bug cpuinfo

### DIFF
--- a/utils/get_combustion_toolbox_version.m
+++ b/utils/get_combustion_toolbox_version.m
@@ -7,6 +7,6 @@ function [release, date] = get_combustion_toolbox_version()
     %     * release (char): Release version
     %     * date (char): Release date
 
-    release = 'v1.0.2';
-    date = '12 May 2023';
+    release = 'v1.0.3';
+    date = '18 May 2024';
 end


### PR DESCRIPTION
Updated [cpuinfo.m](https://github.com/BJTor/CPUInfo) to the last version 1.6.

This version fixed the errors (cache clock, OS type, version, ...) with Apple Silicon Macs. 